### PR TITLE
Stream publish fix on iOS

### DIFF
--- a/ios/RTMPCreator.swift
+++ b/ios/RTMPCreator.swift
@@ -38,7 +38,6 @@ class RTMPCreator {
     public static func startPublish(){
         connection.requireNetworkFramework = true
         connection.connect(_streamUrl)
-        stream.publish(_streamName)
         isStreaming = true
     }
   

--- a/ios/RTMPManager/RTMPView.swift
+++ b/ios/RTMPManager/RTMPView.swift
@@ -84,6 +84,7 @@ class RTMPView: UIView {
               onConnectionSuccess!(nil)
             }
            changeStreamState(status: "CONNECTING")
+           RTMPCreator.stream.publish(streamName as String)
            break
        
        case RTMPConnection.Code.connectFailed.rawValue:


### PR DESCRIPTION
The publish method from RTMPStream must be executed after the connection success event. At least for me, the stream is broken after the first successful publish without this change.