### PR TITLE
Bump HaishinKit.swift to 1.4.3. Fix iOS 2nd stream

### DIFF
--- a/ios/RTMPCreator.swift
+++ b/ios/RTMPCreator.swift
@@ -38,7 +38,6 @@ class RTMPCreator {
     public static func startPublish(){
         connection.requireNetworkFramework = true
         connection.connect(_streamUrl)
-        stream.publish(_streamName)
         isStreaming = true
     }
   

--- a/ios/RTMPManager/RTMPView.swift
+++ b/ios/RTMPManager/RTMPView.swift
@@ -81,6 +81,7 @@ class RTMPView: UIView {
               onConnectionSuccess!(nil)
             }
            changeStreamState(status: "CONNECTING")
+           RTMPCreator.stream.publish(streamName as String)
            break
        
        case RTMPConnection.Code.connectFailed.rawValue:

--- a/ios/RTMPManager/RTMPView.swift
+++ b/ios/RTMPManager/RTMPView.swift
@@ -64,9 +64,6 @@ class RTMPView: UIView {
        fatalError("init(coder:) has not been implemented")
      }
     
-    override func removeFromSuperview() {
-        print("ON REMOVE")
-    }
   
     @objc
     private func statusHandler(_ notification: Notification){

--- a/ios/RTMPManager/RTMPView.swift
+++ b/ios/RTMPManager/RTMPView.swift
@@ -37,12 +37,9 @@ class RTMPView: UIView {
     hkView = MTHKView(frame: UIScreen.main.bounds)
     hkView.videoGravity = .resizeAspectFill
     
-    RTMPCreator.stream.captureSettings = [
-        .fps: 30,
-        .sessionPreset: AVCaptureSession.Preset.hd1920x1080,
-        .continuousAutofocus: true,
-        .continuousExposure: true
-    ]
+    RTMPCreator.stream.frameRate = 30
+    RTMPCreator.stream.sessionPreset = AVCaptureSession.Preset.hd1920x1080
+      
 
     RTMPCreator.stream.videoSettings = [
         .width: 720,
@@ -53,7 +50,7 @@ class RTMPView: UIView {
     ]
 
     RTMPCreator.stream.attachAudio(AVCaptureDevice.default(for: .audio))
-    RTMPCreator.stream.attachCamera(DeviceUtil.device(withPosition: AVCaptureDevice.Position.back))
+    RTMPCreator.stream.attachCamera(AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back))
 
     RTMPCreator.connection.addEventListener(.rtmpStatus, selector: #selector(statusHandler), observer: self)
 

--- a/ios/RTMPModule/RTMPModule.swift
+++ b/ios/RTMPModule/RTMPModule.swift
@@ -27,18 +27,20 @@ class RTMPModule: NSObject {
 
     @objc
     func mute(_ resolve: (RCTPromiseResolveBlock), reject: (RCTPromiseRejectBlock)){
-        RTMPCreator.stream.audioSettings[.muted] = true
+        RTMPCreator.stream.hasAudio = false
     }
 
     @objc
     func unmute(_ resolve: (RCTPromiseResolveBlock), reject: (RCTPromiseRejectBlock)){
-        RTMPCreator.stream.audioSettings[.muted] = false
+        RTMPCreator.stream.hasAudio = true
     }
 
     @objc
     func switchCamera(_ resolve: (RCTPromiseResolveBlock), reject: (RCTPromiseRejectBlock)){
         cameraPosition = cameraPosition == .back ? .front : .back
-        RTMPCreator.stream.attachCamera(DeviceUtil.device(withPosition: cameraPosition))
+        RTMPCreator.stream.attachCamera(
+            AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: cameraPosition)
+        )
     }
 
     @objc

--- a/react-native-rtmp-publisher.podspec
+++ b/react-native-rtmp-publisher.podspec
@@ -10,12 +10,12 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "10.0" }
+  s.platforms    = { :ios => "11.0" }
   s.source       = { :git => "https://github.com/ezranbayantemur/react-native-rtmp-publisher.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "HaishinKit", "~> 1.2.7"
+  s.dependency "HaishinKit", "~> 1.4.3"
   
 end


### PR DESCRIPTION
Increased version of [HaishinKit.swift](https://github.com/shogo4405/HaishinKit.swift) in order to support rtmps links.
Changed DeviceUtil to AVCaptureDevice to migrate to new HaishinKit.swift version.
Fixed switching camera and muting/unmuting on new version of HaishinKit.swift.
Increased minimum supported version of iOS to 11.
Added suggestion from this MR https://github.com/ezranbayantemur/react-native-rtmp-publisher/pull/35 to fix 2nd stream on ios